### PR TITLE
Fix NextAuth session typing for user id access

### DIFF
--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,19 @@
+import type { DefaultSession } from 'next-auth'
+
+declare module 'next-auth' {
+  interface Session {
+    user: {
+      id: string
+    } & DefaultSession['user']
+  }
+
+  interface User {
+    id: string
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    id: string
+  }
+}


### PR DESCRIPTION
## Summary
- add a NextAuth type augmentation so Session.user exposes the id field
- align JWT typing with the stored id for downstream access

## Testing
- npm run build *(fails: Next.js cannot download Inter font files from fonts.gstatic.com in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd23f37c98832d85de791594ef0862